### PR TITLE
Convert JS to ES modules

### DIFF
--- a/js/ui/menu.js
+++ b/js/ui/menu.js
@@ -428,24 +428,35 @@ function createReference () {
   })
 
   function populateRefKeypad () {
-    var refPadArr = ['row-start', 'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', 'row-end', 'row-start', 'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'row-end', 'row-start', 'z', 'x', 'c', 'v', 'b', 'n', 'm', 'row-end', 'row-start', 'space', 'clear', 'random', 'row-end']
-    var txtPad = "<input type='hidden' id='refPadHiddenValue' />"
-    var i
-    for (i = 0; i < refPadArr.length; i++) {
-      if (refPadArr[i] === 'row-start') {
-        txtPad = txtPad + "<div class='refpad--row'>"
-      } else if (refPadArr[i] === 'row-end') {
-        txtPad = txtPad + '</div>'
-      } else {
-        if (refPadArr[i].length > 0) {
-          txtPad = txtPad + "<div class='refpad__pad -" + refPadArr[i] + "' onClick='refPadEntry(\"" + refPadArr[i] + "\")'>" + refPadArr[i] + '</div>'
-        } else {
-          txtPad = txtPad + "<div class='refpad__pad' onClick='refPadEntry(\"" + refPadArr[i] + "\")'>" + refPadArr[i] + '</div>'
-        }
+    const refPadArr = [
+      ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
+      ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'],
+      ['z', 'x', 'c', 'v', 'b', 'n', 'm'],
+      ['space', 'clear', 'random'],
+    ]
+
+    const keypadEl = $('#reference-window-keypad').empty()
+    const txtPadEl = $("<input type='hidden' id='refPadHiddenValue'>")
+
+    keypadEl.append(txtPadEl)
+
+    for (let row of refPadArr) {
+      let rowEl = $("<div class='refpad--row'></div>")
+
+      for (let label of row) {
+        let labelEl = $('<div></div>')
+          .addClass('refpad__pad')
+          .addClass(`-${label}`)
+          .text(label)
+          .on('click', function () {
+            refPadEntry(label)
+          })
+
+        rowEl.append(labelEl)
       }
+
+      keypadEl.append(rowEl)
     }
-    let refKeypad = document.getElementById('reference-window-keypad')
-    refKeypad.innerHTML = txtPad
   }
 
   $('#reference').hover(function () {


### PR DESCRIPTION
Initial work to convert the contents of `js/*` to ES modules. Each commit contains only a small amount of changes, typically one file at a time to make the review process easier. The project should run without issues for all commits.

**Preparation Summary:**
This part is almost entirely refactoring without modifying any behaviour other than to `index_template.html` which is explained below.
- Move third-party code to `js/vendor`
- Move ui elements to `js/ui`
- Move inline JS from html templates to `js/scenes`
- Removed `index_template.html`, `build.sh` has been updated to inject the version into the variable `window.globals.version`
- Added/run eslint with `standard` profile `npm run lint`

**Modularization**
Code changes begin at commit 04ab0210, there are two minor bugs squashed in commits aec123c3 and 
6f599c1f as well.
- Minimal modifications to `js/scenes` to convert from jQuery document ready to modules
- From commit f72dc205 one `js/ui` script is converted to a module per commit

Overall it should be a bit easier to work out dependencies and is a step towards making classes where appropriate, the first one I want to tackle is settings to add a windowed mode option. As discussed previously, I'm looking to use webpack and a standard browser to prototype quicker, this should be fairly trivial after these changes.